### PR TITLE
fix python3 symlink

### DIFF
--- a/gpu/Dockerfile.base
+++ b/gpu/Dockerfile.base
@@ -41,6 +41,7 @@ RUN apt-get update \
   && apt-get update \
   && apt-get install -y python3.6 python3.6-dev \
   && ln -s /usr/bin/python3.6 /usr/local/bin/python \
+  && ln -fs /usr/bin/python3.6 /usr/bin/python3 \
   && curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
   && python get-pip.py \
   && rm get-pip.py \


### PR DESCRIPTION
python3 was linked to py3.5, move to py3.6